### PR TITLE
Use of internal bounding interval info and loose bounding intervals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ git submodule update --init --recursive
 
 ## Compiling:
 
-The project uses CMake. It is recommended that you compile in a directory purposely
+The metric tree and metrics (in directories search and metric, respectively) are 
+in header only files. You may include these as so in you project. To work within
+the provided CMake project, is recommended that you compile in a directory purposely
 set aside for compiling. Say this directory is to be called "build". Consider
 performing these operations :
 
@@ -44,12 +46,35 @@ cmake ..
 make
 ```
 
+You may change compiler, compilation flags and compilation options manually. One popular choice (for gnu, debug version, using bash) is:
+```
+export CC=gcc
+export CXX=g++
+export CFLAGS="-g -O0  -Wall -Wpedantic -Wextra"
+export CXXFLAGS="-g -O0 -Wall -Wpedantic -Wextra"
+cd CMT/src
+mkdir build
+cd build
+cmake .. 
+cmake --build . -v 
+```
+
+ Additionally, to change the build options USE_HALF_INTERVALS and USE_NEXTAFTER away
+ from their defaults, the step  ``` cmake ..``` above can be replaced by:
+```cmake .. -DUSE_HALF_INTERVALS=ON  -DUSE_NEXTAFTER=OFF```
+
 Note that the executables will be automatically placed in directory CMT/bin.
+
+Some applications can use the parasail library to evaluate biosequence metrics.
+By default this option is turned off and may be selected by configuring with the
+compile option ```-DUSE_PARASAIL_LIB=ON```. Additionally one needs to modify the 
+toplevel CMakeLists.txt to specify the location of the parasail library.
+
 
 ## Using the VS Code IDE: 
 
 Technically no particular IDE is required to change, compile debug and add code,
-but development has largely been with Microsoft VS Code and that is what we recommend.
+but development has largely been with Microsoft VS Code.
 Open with Code (with "File -> Open Folder") the directory CMT and the file explorer
 should show the direcotry structure.
 

--- a/src/.vscode/c_cpp_properties.json
+++ b/src/.vscode/c_cpp_properties.json
@@ -6,11 +6,18 @@
                 "${workspaceFolder}/**"
             ],
             "defines": [],
-            "compilerPath": "/usr/bin/gcc",
+            "compilerPath": "/usr/bin/clang",
             "cStandard": "c17",
-            "cppStandard": "c++17",
-            "intelliSenseMode": "clang-x64",
-            "configurationProvider": "ms-vscode.cmake-tools"
+            "cppStandard": "c++14",
+            "intelliSenseMode": "linux-clang-x64",
+            "mergeConfigurations": false,
+            "configurationProvider": "ms-vscode.cmake-tools",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}/**"
+                ],
+                "limitSymbolsToIncludedHeaders": true
+            }
         }
     ],
     "version": 4

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -58,7 +58,13 @@
         "streambuf": "cpp",
         "thread": "cpp",
         "typeinfo": "cpp",
-        "cinttypes": "cpp"
+        "cinttypes": "cpp",
+        "compare": "cpp",
+        "concepts": "cpp",
+        "numbers": "cpp",
+        "semaphore": "cpp",
+        "stop_token": "cpp"
     },
-    "cmake.configureOnOpen": false
+    "cmake.configureOnOpen": false,
+    "C_Cpp.dimInactiveRegions": true
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,9 @@ message(STATUS "Setting MSVC flags")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc /std:c++latest")	
 ]]	
 
+option(USE_NEXTAFTER "Use nextafter expanded bounding intervals" ON)
+option(USE_HALFINTERVALS "Use half intervals instead of full intervals" OFF)
+option(USE_PARASAIL_LIB "Use the parasial library to evaluate bioseqeunce distances" OFF)
 
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/../bin")	
@@ -27,7 +30,26 @@ add_dependencies(libMetric libCommon)
 add_dependencies(libSearch libCommon)	
 add_dependencies(EuclidSearchApp  libCommon libMetric libSearch)	
 add_dependencies(EditDistSearchApp  libCommon libMetric libSearch)	
-add_dependencies(ExtractFastaApp  libCommon libMetric libSearch)	
+add_dependencies(ExtractFastaApp  libCommon libMetric libSearch)
+
+if (USE_NEXTAFTER)
+  add_definitions(-DUSE_NEXTAFTER)
+  target_compile_definitions(EditDistSearchApp PUBLIC USE_NEXTAFTER=${USE_NEXTAFTER})
+  target_compile_definitions(EuclidSearchApp PUBLIC USE_NEXTAFTER=${USE_NEXTAFTER})
+endif()
+
+if (USE_HALF_INTERVALS)
+  add_definitions(-DUSE_HALF_INTERVALS)
+  target_compile_definitions(EditDistSearchApp PUBLIC USE_HALF_INTERVALS=${USE_HALF_INTERVALS})
+  target_compile_definitions(EuclidSearchApp PUBLIC USE_HALF_INTERVALS=${USE_HALF_INTERVALS})
+endif()
+
+
+if (USE_PARASAIL_LIB)
+  add_definitions(-DUSE_PARASAIL_LIB)
+  target_compile_definitions(EditDistSearchApp PUBLIC USE_PARASAIL_LIB=${USE_PARASAIL_LIB})
+  target_compile_definitions(ExtractFastaApp PUBLIC USE_PARASAIL_LIB=${USE_PARASAIL_LIB})
+endif()
 
 
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tapps)

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -1,13 +1,12 @@
 #set(staticlib "-static-libgcc -static-libstdc++")
 
 include_directories(${CMAKE_SOURCE_DIR}/../include)
+
 #parassail lib include location: 
 include_directories(/home/mzuniga/usr/local/include)
-#include_directories(${CMAKE_SOURCE_DIR}/common)
-#include_directories(${CMAKE_SOURCE_DIR}/metric)
-#include_directories(${CMAKE_SOURCE_DIR}/search)
 
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+
 #parsail lib lib location:
 link_directories(/home/mzuniga/usr/local/lib)
 
@@ -36,5 +35,3 @@ target_link_libraries(EditDistSearchApp  libCommon)
 target_link_libraries(EditDistSearchApp libMetric)
 target_link_libraries(EditDistSearchApp libSearch)
 target_link_libraries(EditDistSearchApp edlib)
-
-

--- a/src/apps/EditDistSearchMain.cpp
+++ b/src/apps/EditDistSearchMain.cpp
@@ -1,76 +1,66 @@
 //#define SA_USE_STATIC_DI
 
-#include <iostream>
-#include <string>
-#include <vector>
-#include <fstream>
-#include <thread>
 #include <chrono>
+#include <fstream>
+#include <iostream>
 #include <regex>
+#include <string>
+#include <thread>
+#include <vector>
 
 #include "EditDistanceTests.h"
 
 #ifdef __WIN32
 unsigned int DistanceIntervalSM<float>::used = 0;
-std::vector< DistanceIntervalSM<float>> DistanceIntervalSM<float>::data;
+std::vector<DistanceIntervalSM<float>> DistanceIntervalSM<float>::data;
 #endif
 
 int main(int argc, char* argv[]) {
-	using namespace std;
+    using namespace std;
 
-	string bfn {"/home/mzuniga/data"};
-	string fileNamePrefix = { "mtreeRunTimes_EDM" };
-	string cmFileName{ "checkMetrics.txt" };
-	string sweFileName{ "SWExamples.txt" };
-	string pairsFileName{ "pairsFileName.txt" };
-	string sprotFileName{ bfn + "/UniProt/uniprot_sprot.fasta"};
-	string tremblFileName{ bfn + "/UniProt/TREMBL/uniprot_trembl_500000.fasta" };
-	string uproMammalsFileName{ bfn + "/UniProt/TREMBL/mammals/uniprot_trembl_mammals_500000.fasta" };
-	string influenzaFileName{ bfn + "/HA/influenza.fna" };
-    string haEncodingFileName{ bfn + "/HA/enc_09/ha_enc09.fasta"};
-	string hivDirName{ bfn + "/HIV1" };
-	string pridePrejFileName(bfn + "/text/words.txt");
-	string dictionFileName(bfn + "/dictionary/dic_en_us_gb_au_lcunique.txt");
-			
-	/*   EDIT DISTANCE TESTS */
+    string bfn{"/home/mzuniga/data"};
+    string fileNamePrefix = {"mtreeRunTimes_EDM"};
+    string cmFileName{"checkMetrics.txt"};
+    string sweFileName{"SWExamples.txt"};
+    string pairsFileName{"pairsFileName.txt"};
+    string sprotFileName{bfn + "/UniProt/uniprot_sprot.fasta"};
+    string tremblFileName{bfn + "/UniProt/TREMBL/uniprot_trembl_500000.fasta"};
+    string uproMammalsFileName{bfn + "/UniProt/TREMBL/mammals/uniprot_trembl_mammals_500000.fasta"};
+    string influenzaFileName{bfn + "/HA/influenza.fna"};
+    string haEncodingFileName{bfn + "/HA/enc_09/ha_enc09.fasta"};
+    string hivDirName{bfn + "/HIV1"};
+    string pridePrejFileName(bfn + "/text/words.txt");
+    string dictionFileName(bfn + "/dictionary/dic_en_us_gb_au_lcunique.txt");
 
-	//RADIUS (RANGE) SEARCH TESTS
-	//radiusSearchTestEDM(fileNamePrefix , dictionFileName);
-	//radiusSearchTestEDM_S(fileNamePrefix +"_sp_mo1_", sprotFileName);
-	//radiusSearchTestEDM_S(fileNamePrefix + "_sprot_radius", sprotFileName);
+    /*   EDIT DISTANCE TESTS */
 
+    // RADIUS (RANGE) SEARCH TESTS
+    // radiusSearchTestEDM(fileNamePrefix , dictionFileName);
+    //radiusSearchTestEDM(fileNamePrefix + "_sp", sprotFileName);
+    // radiusSearchTestEDM_S(fileNamePrefix + "_sprot_radius", sprotFileName);
 
-	// KNN SEARCH TESTS
+    // KNN SEARCH TESTS
 
-	//nkSearchTestEDM_EXQ(fileNamePrefix + "_spro_nk" , sprotFileName);
-	//KNN+RANGE EQUIV SEARCH TESTS
-	//nkRsSearchTestEDM(fileNamePrefix + "_SwissProt_" , sprotFileName);
-	//nkSearchTestEDM_EXQ_NP(fileNamePrefix + "_spro_np_nk" , sprotFileName);
+    //nkSearchTestEDM_EXQ(fileNamePrefix + "_spro_nk", sprotFileName);
+    // KNN+RANGE EQUIV SEARCH TESTS
+    // nkRsSearchTestEDM(fileNamePrefix + "_SwissProt_" , sprotFileName);
+     nkSearchTestEDM_EXQ_NP(fileNamePrefix + "_spro_np_nk" , sprotFileName);
 
-	//COMPARE AWNSERS FOR CORRECTNESS TESTS:
-	//kNNCompareEDM(fileNamePrefix + "_knncmp", dictionFileName, 100000, 100, 10 , PivotType::RAN, PartType::BOM, true);
+    // COMPARE AWNSERS FOR CORRECTNESS TESTS:
+    // kNNCompareEDM(fileNamePrefix + "_knncmp", dictionFileName, 100000, 1000, 10 , PivotType::RAN, PartType::BOM, true);
 
-	//KNN search with initial radius
-	nkSearchTestEDM_EXQ(fileNamePrefix + "_spro_rknn" , sprotFileName);
+    // KNN search with initial radius
+    //nkSearchTestEDM_EXQ(fileNamePrefix + "_spro_rknn_short" , sprotFileName);
 
-	//nkIncreasingDensityTestEM(100000, 10000, PivotType::RAN, PartType::PIV, 5, fileNamePrefix + "_id");
-	//nkIncreasingDensityTestEM(fileNamePrefix + "_id");
+    // nkIncreasingDensityTestEM(100000, 10000, PivotType::RAN, PartType::PIV, 5, fileNamePrefix + "_id");
+    // nkIncreasingDensityTestEM(fileNamePrefix + "_id");
 
+    // collectSearchTestEDM_V2(fileNamePrefix + "_sprot" , sprotFileName, 0, 24, 50);
+    // collectSearchTestEDM_V2(fileNamePrefix + "_sprot_zoom" , sprotFileName, 0, 10, 10);
 
-	//collectSearchTestEDM_V2(fileNamePrefix + "_sprot" , sprotFileName, 0, 24, 50);
-	//collectSearchTestEDM_V2(fileNamePrefix + "_sprot_zoom" , sprotFileName, 0, 10, 10);
-	
+    // collectCountSearchTestEDM(fileNamePrefix + "_Sprot_count_10K" , sprotFileName);
 
-	//collectCountSearchTestEDM(fileNamePrefix + "_Sprot_count_10K" , sprotFileName);
+    // treeStatsTests("treeStrucStats_kimmo_rs" , dictionFileName);
 
-
-	//treeStatsTests("treeStrucStats_kimmo_rs" , dictionFileName);
- 
-	return 0;
-
+    return 0;
 }
-
-
-
-
-

--- a/src/apps/EuclidSearchMain.cpp
+++ b/src/apps/EuclidSearchMain.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
 	/*  EUCLIDIAN METRIC TESTS */
 	
 	//radiusSearchTestEM(fileNamePrefix);
-	//radiusSearchTestEM_S(fileNamePrefix);
+	radiusSearchTestEM_S(fileNamePrefix);
 
 	//the count-only version of radius search
 	//radiusSearchTestEMCount(fileNamePrefix);
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) {
 	//nkSearchTestEM(fileNamePrefix + "_DIM10");
 	//nkSearchTestEM(fileNamePrefix + "_DIM10_nk");
 	//nkSearchTestEM(fileNamePrefix + "_LCMTs_DIM10");
-	//nkSearchTestEM_S(fileNamePrefix + "_DIMSS_IQI_V2");
+	nkSearchTestEM(fileNamePrefix + "_DIM10");
 	
 	//---------------------------------------------------------------------------------
 	//radiusSearchCompareEM(fileNamePrefix);
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
 	//--------------------------------------------------------
 	//collectSearchTestEM(fileNamePrefix + "_pf");
 	//collectSearchTestEMAutoRad(fileNamePrefix + "_DIM10b_zoom", 30, 0.3);
-	collectSearchTestEMAutoRad(fileNamePrefix + "_DIM10b", 10, 0.9);
+	//collectSearchTestEMAutoRad(fileNamePrefix + "_DIM10b", 10, 0.9);
 	
 	//collectCountSearchTestEM(fileNamePrefix);
 	//collectCountSearchPlusTestEM(fileNamePrefix + "_2parts");

--- a/src/apps/EuclidSearchMain.cpp
+++ b/src/apps/EuclidSearchMain.cpp
@@ -1,9 +1,9 @@
+#include <chrono>
+#include <fstream>
 #include <iostream>
 #include <string>
-#include <vector>
-#include <fstream>
 #include <thread>
-#include <chrono>
+#include <vector>
 
 #include "EuclidianTests.h"
 #include "Metric.h"
@@ -11,57 +11,49 @@
 
 #ifdef __WIN32
 unsigned int DistanceIntervalSM<float>::used = 0;
-std::vector< DistanceIntervalSM<float>> DistanceIntervalSM<float>::data;
+std::vector<DistanceIntervalSM<float>> DistanceIntervalSM<float>::data;
 #endif
 
 int main(int argc, char* argv[]) {
-	using namespace std;
+    using namespace std;
 
-	string fileNamePrefix = { "mtreeRunTimes_EM" };
+    string fileNamePrefix = {"mtreeRunTimes_EM"};
 
-	/*  EUCLIDIAN METRIC TESTS */
-	
-	//radiusSearchTestEM(fileNamePrefix);
-	//radiusSearchTestEM_S(fileNamePrefix);
+    /*  EUCLIDIAN METRIC TESTS */
 
-	//the count-only version of radius search
-	//radiusSearchTestEMCount(fileNamePrefix);
+    // radiusSearchTestEM(fileNamePrefix);
+    // radiusSearchTestEM_S(fileNamePrefix);
 
+    // the count-only version of radius search
+    // radiusSearchTestEMCount(fileNamePrefix);
 
-	//radiusSearchTestEM_Brin95  (fileNamePrefix + "_Brin95");
+    // radiusSearchTestEM_Brin95  (fileNamePrefix + "_Brin95");
 
-	//nkSearchTestEM(fileNamePrefix + "_DIM10");
-	//nkSearchTestEM(fileNamePrefix + "_DIM10_nk");
-	//nkSearchTestEM(fileNamePrefix + "_LCMTs_DIM10");
-	//nkSearchTestEM(fileNamePrefix + "_DIM10");
-	
-	//---------------------------------------------------------------------------------
-	//radiusSearchCompareEM(fileNamePrefix);
-	//radiusSearchCompareEM(10000, 4, PivotType::RAN, PartType::DMR, fileNamePrefix);
-	//----------------------------------------------------------------------------------
-	
-	//---------------------------------------------
-	//nkRsSearchTestEM(fileNamePrefix + "_DIM10_D");
+    // nkSearchTestEM(fileNamePrefix + "_DIM10");
+    // nkSearchTestEM(fileNamePrefix + "_DIM10_nk");
+    // nkSearchTestEM(fileNamePrefix + "_LCMTs_DIM10");
+    // nkSearchTestEM(fileNamePrefix + "_DIM10");
 
-	//--------------------------------------------------------
-	//collectSearchTestEM(fileNamePrefix + "_pf");
-	collectSearchTestEMAutoRad(fileNamePrefix + "_DIM10b_zoom", 30, 0.3);
-	//collectSearchTestEMAutoRad(fileNamePrefix + "_DIM10b", 10, 0.9);
-	
-	//collectCountSearchTestEM(fileNamePrefix);
-	//collectCountSearchPlusTestEM(fileNamePrefix + "_2parts");
+    //---------------------------------------------------------------------------------
+    // radiusSearchCompareEM(fileNamePrefix);
+    // radiusSearchCompareEM(10000, 4, PivotType::RAN, PartType::DMR, fileNamePrefix);
+    //----------------------------------------------------------------------------------
 
-	
-	//------------------------------------------------------
-	//kNNSearchCompareEM(100000, 1000, PivotType::RAN, PartType::DMR, 1, fileNamePrefix, true);
+    //---------------------------------------------
+    // nkRsSearchTestEM(fileNamePrefix + "_DIM10_D");
 
-	//nkIncreasingDensityTestEM(100000, 10000, PivotType::RAN, PartType::PIV, 5, fileNamePrefix + "_id");
-	//nkIncreasingDensityTestEM(fileNamePrefix + "_id");
-	return 0;
+    //--------------------------------------------------------
+    // collectSearchTestEM(fileNamePrefix + "_pf");
+    // collectSearchTestEMAutoRad(fileNamePrefix + "_DIM10b_zoom", 30, 0.3);
+    // collectSearchTestEMAutoRad(fileNamePrefix + "_DIM10b", 10, 0.9);
+
+    // collectCountSearchTestEM(fileNamePrefix);
+    // collectCountSearchPlusTestEM(fileNamePrefix + "_2parts");
+
+    //------------------------------------------------------
+    kNNSearchCompareEM(100000, 10000, PivotType::RAN, PartType::BOM, 1, fileNamePrefix, true);
+
+    // nkIncreasingDensityTestEM(100000, 10000, PivotType::RAN, PartType::PIV, 5, fileNamePrefix + "_id");
+    // nkIncreasingDensityTestEM(fileNamePrefix + "_id");
+    return 0;
 }
-
-
-
-
-
-

--- a/src/apps/EuclidianTests.h
+++ b/src/apps/EuclidianTests.h
@@ -295,6 +295,7 @@ void radiusSearchTestEM_Brin95(const std::string& fileNamePrefix) {
 
 	std::vector<int> cmt_madis{1};
 	std::vector<int> spmt_madis{0};
+	std::vector<int> apmt_madis{0};
 
 	std::set<PivotType> includePivotTypes{ PivotType::RAN};
 	std::set<PartType>  includePartTypes{ PartType::BOM };
@@ -314,6 +315,11 @@ void radiusSearchTestEM_Brin95(const std::string& fileNamePrefix) {
 				}
 				for (const auto& madi : spmt_madis){
 					radiusSearchTest<EuclidianPoint, EuclidianMetric,SPMTree<EuclidianPoint, EuclidianMetric>>
+					(points, qPoints, EuclidianPointDim, radii, pivType, partType, madi, fileNamePrefix, hflag);
+					hflag = false; //Dont print header after 1st time.
+				}
+				for (const auto& madi : apmt_madis){
+					radiusSearchTest<EuclidianPoint, EuclidianMetric,APMTree<EuclidianPoint, EuclidianMetric>>
 					(points, qPoints, EuclidianPointDim, radii, pivType, partType, madi, fileNamePrefix, hflag);
 					hflag = false; //Dont print header after 1st time.
 				}
@@ -649,9 +655,10 @@ void collectSearchTestEM(const std::string& fileNamePrefix) {
 
 */
 void collectSearchTestEMAutoRad(const std::string& fileNamePrefix, int nrad, float maxRadPct) {
-	std::map<unsigned int, unsigned int> nofPoints{{10000,100 } ,{100000,100 } , {1000000,100 } , {10000000,100 }};
+	//std::map<unsigned int, unsigned int> nofPoints{{10000,100 } ,{100000,100 } , {1000000,100 } , {10000000,100 }};
 	//std::map<unsigned int, unsigned int> nofPoints{{10000,100 } ,{100000,100 } , {1000000,100 }};
 	//std::map<unsigned int, unsigned int> nofPoints{{10000000,100 }};
+	std::map<unsigned int, unsigned int> nofPoints{{100000,100 }};
     std::vector<float> radii;
 	bool rangeSearchToo = true;
 	

--- a/src/apps/EuclidianTests.h
+++ b/src/apps/EuclidianTests.h
@@ -291,9 +291,9 @@ void radiusSearchTestEM_Brin95(const std::string& fileNamePrefix) {
 	//Set the DB sizes and number of queries that we want to test
 	//std::map<unsigned int, unsigned int> nofPoints = getTestSizes(2, 10,18,1, 10000) ;
 	std::map<unsigned int, unsigned int> nofPoints{ {3000,100}, {20000,100 }};
-	std::vector<float>  radii {0.0f, 0.000001f, 0.001f, 0.1f};
+	std::vector<float>  radii {0.0f, 0.000001f, 0.25f, 0.5f};
 
-	std::vector<int> cmt_madis{1};
+	std::vector<int> cmt_madis{1, 1000};
 	std::vector<int> spmt_madis{0};
 	std::vector<int> apmt_madis{0};
 
@@ -336,9 +336,8 @@ void radiusSearchTestEM_Brin95(const std::string& fileNamePrefix) {
 
 void nkSearchTestEM(const std::string &fileNamePrefix){
 	//std::map<unsigned int, unsigned int> nofPoints = getTestSizes(2, 10,18,1, 10000) ;
-	std::map<unsigned int, unsigned int> nofPoints{{1000, 100}, {10000, 100}, {100000, 100}, {1000000, 100},
-		{10000000, 100}};
-	std::vector<unsigned int> maxResults{1, 2 , 4, 6, 8,  10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000};
+	std::map<unsigned int, unsigned int> nofPoints{{1000, 100}, {10000, 100}, {100000, 100}, {1000000, 100},};
+	std::vector<unsigned int> maxResults{1, 2 , 4, 6, 8,  10, 20, 40, 60, 80, 100};
 
 	//Short test
 	//std::map<unsigned int, unsigned int> nofPoints{ {100000, 1000}};
@@ -350,7 +349,7 @@ void nkSearchTestEM(const std::string &fileNamePrefix){
 
 
 	std::set<PivotType> includePivotTypes{PivotType::RAN};
-	std::set<PartType> includePartTypes{PartType::BOM, PartType::DMR};
+	std::set<PartType> includePartTypes{PartType::BOM};
 
 	bool hflag = true;
 	std::vector<EuclidianPoint> points, qPoints;
@@ -834,8 +833,8 @@ void kNNSearchCompareEM(unsigned int nPoints, unsigned int nQueries,
 
 
 	std::clock_t start = std::clock();
-	//CMTree<EuclidianPoint, MetricType> stree(points, met, pivT, partT, kxBalancedTreeHeight(1, points.size()));
-	APMTree<EuclidianPoint, MetricType> stree(points, met, pivT, partT, 0);
+	CMTree<EuclidianPoint, MetricType> stree(points, met, pivT, partT, kxBalancedTreeHeight(1, points.size()));
+	//APMTree<EuclidianPoint, MetricType> stree(points, met, pivT, partT, 0);
 
 	BruteForceSearch<EuclidianPoint, MetricType> stree2(points, met);
 

--- a/src/apps/EuclidianTests.h
+++ b/src/apps/EuclidianTests.h
@@ -168,20 +168,15 @@ void getDataBounds(std::vector<EuclidianPoint>& points, std::array<EuclidianPoin
 void radiusSearchTestEM(const std::string& fileNamePrefix) {
 	//Set the DB sizes and number of queries that we want to test
 	//std::map<unsigned int, unsigned int> nofPoints = getTestSizes(2, 10,18,1, 10000) ;
-	//std::map<unsigned int, unsigned int> nofPoints{ {1000,100}, {10000,1000 } ,{100000,1000 } ,{1000000,1000 } };
-	std::map<unsigned int, unsigned int> nofPoints{  {10000,1000 }  };
+	std::map<unsigned int, unsigned int> nofPoints{ {1000,100}, {10000,1000 } ,{100000,1000 } ,{1000000,1000 } };
+	std::vector<float> radii {0.5f, 1.0f, 1.5f, 2.0f, 2.5f, 3.0f};
 
-	//std::vector<float> radii {0.5f, 1.0f, 1.5f, 2.0f, 2.5f, 3.0f};
-	std::vector<float> radii {1.0f};
-
-	//std::vector<float> lcmt_npivs {0.25, 0.5, 1.0, 2.0, 3.0 };
-	//std::vector<int> cmt_madis {1000, 1};
-
-	std::vector<float> lcmt_npivs ;
-	std::vector<int> cmt_madis {1000};
+	std::vector<int> cmt_madis{1 , 1000};//,1};
+	std::vector<int> spmt_madis{0};
+	std::vector<int> apmt_madis{0};
 
 	std::set<PivotType> includePivotTypes{ PivotType::RAN};
-	std::set<PartType>  includePartTypes{ PartType::BOM};
+	std::set<PartType>  includePartTypes{ PartType::BOM, PartType::DMR};
 	bool hflag = true;
 	std::vector<EuclidianPoint> points, qPoints;
 	for (const auto& [np, nQueries] : nofPoints) {
@@ -191,6 +186,17 @@ void radiusSearchTestEM(const std::string& fileNamePrefix) {
 			for (const auto& partType : includePartTypes) {
 				for (const auto& madi : cmt_madis){
 					radiusSearchTest<EuclidianPoint, EuclidianMetric,CMTree<EuclidianPoint, EuclidianMetric>>
+					(points, qPoints, EuclidianPointDim, radii, pivType, partType, madi, fileNamePrefix, hflag);
+					hflag = false; //Dont print header after 1st time.
+				}
+				for (const auto& madi : spmt_madis){
+					if(partType == PartType::DMR) continue;
+					radiusSearchTest<EuclidianPoint, EuclidianMetric,SPMTree<EuclidianPoint, EuclidianMetric>>
+					(points, qPoints, EuclidianPointDim, radii, pivType, partType, madi, fileNamePrefix, hflag);
+					hflag = false; //Dont print header after 1st time.
+				}
+				for (const auto& madi : apmt_madis){
+					radiusSearchTest<EuclidianPoint, EuclidianMetric,APMTree<EuclidianPoint, EuclidianMetric>>
 					(points, qPoints, EuclidianPointDim, radii, pivType, partType, madi, fileNamePrefix, hflag);
 					hflag = false; //Dont print header after 1st time.
 				}
@@ -207,11 +213,11 @@ void radiusSearchTestEM_S(const std::string& fileNamePrefix) {
 	//std::vector<float>  radii { 0.000001f};
 	//std::vector<float>  radii {0.5}
 
-	std::map<unsigned int, unsigned int> nofPoints{ {1000000,1000}};
+	std::map<unsigned int, unsigned int> nofPoints{ {100000,1000}};
 	std::vector<float>  radii {0.0f, 0.000001f, 0.5f, 1.0f, 2.0f};
 
-	std::vector<int> cmt_madis{1, 1000};//,1};
-	std::vector<int> spmt_madis{0}; //{0};
+	std::vector<int> cmt_madis{1 , 1000};//,1};
+	std::vector<int> spmt_madis{0};
 	std::vector<int> apmt_madis{0};
 
 	std::set<PivotType> includePivotTypes{ PivotType::RAN};
@@ -324,21 +330,21 @@ void radiusSearchTestEM_Brin95(const std::string& fileNamePrefix) {
 
 void nkSearchTestEM(const std::string &fileNamePrefix){
 	//std::map<unsigned int, unsigned int> nofPoints = getTestSizes(2, 10,18,1, 10000) ;
-	//std::map<unsigned int, unsigned int> nofPoints{{1000, 100}, {10000, 100}, {100000, 100}, {1000000, 100},
-	//	{10000000, 100}};
-	//std::vector<unsigned int> maxResults{1, 2 , 4, 6, 8,  10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000};
+	std::map<unsigned int, unsigned int> nofPoints{{1000, 100}, {10000, 100}, {100000, 100}, {1000000, 100},
+		{10000000, 100}};
+	std::vector<unsigned int> maxResults{1, 2 , 4, 6, 8,  10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000};
 
-	std::map<unsigned int, unsigned int> nofPoints{ {100000, 100}};
-
-	std::vector<unsigned int> maxResults{1,4,10};
+	//Short test
+	//std::map<unsigned int, unsigned int> nofPoints{ {100000, 1000}};
+	//std::vector<unsigned int> maxResults{1,4,10, 50};
 		
-	std::vector<int> cmt_madis {1,1000};
-	std::vector<int> spmt_madis{0};
+	std::vector<int> cmt_madis{1,1000};
+    std::vector<int> spmt_madis{0};
 	std::vector<int> apmt_madis{0}; // not finished {0};
 
 
 	std::set<PivotType> includePivotTypes{PivotType::RAN};
-	std::set<PartType> includePartTypes{PartType::BOM};
+	std::set<PartType> includePartTypes{PartType::BOM, PartType::DMR};
 
 	bool hflag = true;
 	std::vector<EuclidianPoint> points, qPoints;
@@ -357,11 +363,13 @@ void nkSearchTestEM(const std::string &fileNamePrefix){
 				}
 				
 				for (const auto& madi : spmt_madis){
+					if(partType == PartType::DMR)
+						continue;
 					nkSearchTest<EuclidianPoint, EuclidianMetric,SPMTree<EuclidianPoint, EuclidianMetric>>
 					(points, qPoints, radii, EuclidianPointDim, maxResults, pivType, partType,madi, fileNamePrefix, hflag);
 					if (hflag == true) {hflag = false;}
 				}
-				for (const auto& madi : spmt_madis){
+				for (const auto& madi : apmt_madis){
 					nkSearchTest<EuclidianPoint, EuclidianMetric,APMTree<EuclidianPoint, EuclidianMetric>>
 					(points, qPoints, radii, EuclidianPointDim, maxResults, pivType, partType,madi, fileNamePrefix, hflag);
 					if (hflag == true) {hflag = false;}
@@ -515,7 +523,9 @@ void collectCountSearchTestEM(const std::string& fileNamePrefix) {
 	std::set<PivotType> includePivotTypes{ PivotType::RAN}; 
 	std::set<PartType>  includePartTypes{ PartType::BOM};
 
-	std::vector<int> cmt_madis {1,1000};
+	std::vector<int> cmt_madis{1 , 1000};//,1};
+	std::vector<int> spmt_madis{0};
+	std::vector<int> apmt_madis{0};
 
 	bool hflag = true;
 	std::vector<EuclidianPoint> points, qPoints;
@@ -537,7 +547,9 @@ void collectCountSearchTestEM(const std::string& fileNamePrefix) {
 void collectCountSearchPlusTestEM(const std::string& fileNamePrefix) {
   std::map<unsigned int, unsigned int> nofPoints{{100000, 100}};
 
-   std::vector<float> radii { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 8.5f, 9.0f, 9.5f ,10.0f};
+	std::vector<float> radii { 1.0f, 2.0f, 4.0f, 7.0f ,10.0f};	
+	//two sets below used in PAMI tests
+   //std::vector<float> radii { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 8.5f, 9.0f, 9.5f ,10.0f};
   // std::vector<float> radii
   // { 1.0f, 2.0f, 4.0f,  6.0f,  8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 20.0f, 22.0f, 24.0f, 26.0f, 28.0f, 30.0f};
 
@@ -545,8 +557,9 @@ void collectCountSearchPlusTestEM(const std::string& fileNamePrefix) {
   std::set<PivotType> includePivotTypes{PivotType::RAN};
   std::set<PartType> includePartTypes{PartType::BOM};
 
-  std::vector<float> lcmt_npivs{1, 2, 4};
   std::vector<int> cmt_madis{1, 1000};
+  std::vector<int> spmt_madis{0};
+  std::vector<int> apmt_madis{0};
 
   bool hflag = true;
   std::vector<EuclidianPoint> points, qPoints;
@@ -557,13 +570,22 @@ void collectCountSearchPlusTestEM(const std::string& fileNamePrefix) {
     for (const auto& pivType : includePivotTypes) {
       for (const auto& partType : includePartTypes) {
         for (const auto& madi : cmt_madis) {
-          collectCountSearchTest<EuclidianPoint, EuclidianMetric, CMTree<EuclidianPoint, EuclidianMetric>>(
-              points, qPoints, EuclidianPointDim, radii, false, pivType, partType, madi, fileNamePrefix, hflag);
-          if (hflag == true) {
+         	collectCountSearchTest<EuclidianPoint, EuclidianMetric, CMTree<EuclidianPoint, EuclidianMetric>>
+            (points, qPoints, EuclidianPointDim, radii, false, pivType, partType, madi, fileNamePrefix, hflag);
             hflag = false;
-          }
+          
         }
-      }
+		for (const auto& madi : spmt_madis){
+	  		collectCountSearchTest<EuclidianPoint, EuclidianMetric, SPMTree<EuclidianPoint, EuclidianMetric>>
+            (points, qPoints, EuclidianPointDim, radii, false, pivType, partType, madi, fileNamePrefix, hflag);
+			hflag = false; //Dont print header after 1st time.
+		}
+		for (const auto& madi : apmt_madis){
+		  	collectCountSearchTest<EuclidianPoint, EuclidianMetric, APMTree<EuclidianPoint, EuclidianMetric>>
+            (points, qPoints, EuclidianPointDim, radii, false, pivType, partType, madi, fileNamePrefix, hflag);
+			hflag = false; // Dont print header after 1st time.
+		}
+	  }
     }
   }
 
@@ -586,14 +608,16 @@ void collectCountSearchPlusTestEM(const std::string& fileNamePrefix) {
 void collectSearchTestEM(const std::string& fileNamePrefix) {
 	std::map<unsigned int, unsigned int> nofPoints{ {1000000,100 } };
 	//std::vector<float> radii {0.25f, 0.5f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f}; //For DIM=10
-    std::vector<float> radii {1.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f, 100.0f, 110.0f, 120.0f, 130.0f, 140.0f}; //For DIM=3 1M
-
+    //std::vector<float> radii {1.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f, 100.0f, 110.0f, 120.0f, 130.0f, 140.0f}; //For DIM=3 1M
+	std::vector<float> radii {0.25f, 0.5f, 1.0f, 5.0f}; //For DIM=10
 
 
 	std::set<PivotType> includePivotTypes{ PivotType::RAN}; 
 	std::set<PartType>  includePartTypes{ PartType::BOM};
 
-	std::vector<int> cmt_madis {1, 1000};
+	std::vector<int> cmt_madis;// {1, 1000};
+	std::vector<int> amt_madis {0};
+
 
 	bool hflag = true;
 	std::vector<EuclidianPoint> points, qPoints;
@@ -606,6 +630,11 @@ void collectSearchTestEM(const std::string& fileNamePrefix) {
 					(points, qPoints, EuclidianPointDim, radii, false, pivType, partType, madi, fileNamePrefix, hflag);
 					if (hflag == true) {hflag = false;}
 				}
+				for (const auto& madi : amt_madis){
+					collectSearchTest<EuclidianPoint, EuclidianMetric,APMTree<EuclidianPoint, EuclidianMetric>>
+					(points, qPoints, EuclidianPointDim, radii, false, pivType, partType, madi, fileNamePrefix, hflag);
+					if (hflag == true) {hflag = false;}
+				}
 			}
 		}
 	}
@@ -613,7 +642,7 @@ void collectSearchTestEM(const std::string& fileNamePrefix) {
 
 
 /*
-	Collectionand normal rad search. Radii are auto determined from the
+	Collection and normal range search. Radii are auto determined from the
 	boundaries of the dataset. There are nrad (e.g. 10) evently psaced small radii and
 	nrad evenaly spaced large radii. The largest radii is equal to the 
 	largest distance possible in the hyper-cubed space.
@@ -628,10 +657,11 @@ void collectSearchTestEMAutoRad(const std::string& fileNamePrefix, int nrad, flo
 	
 
 	std::set<PivotType> includePivotTypes{ PivotType::RAN}; 
-	std::set<PartType>  includePartTypes{ PartType::BOM };
+	std::set<PartType>  includePartTypes{ PartType::BOM, PartType::DMR  };
 
 	std::vector<int> cmt_madis{1,1000}; // {1};
 	std::vector<int> spmt_madis{0};// {0};
+	std::vector<int> apmt_madis{0};// {0};
 
 
 	bool hflag = true;
@@ -658,12 +688,12 @@ void collectSearchTestEMAutoRad(const std::string& fileNamePrefix, int nrad, flo
 				for (const auto& madi : cmt_madis){
 					collectSearchTest<EuclidianPoint, EuclidianMetric,CMTree<EuclidianPoint, EuclidianMetric>>
 					(points, qPoints, EuclidianPointDim, radii, false, pivType, partType, madi, fileNamePrefix, hflag, rangeSearchToo);
-					if (hflag == true) {hflag = false;}
+					{hflag = false;}
 				}
-				for (const auto& madi : spmt_madis){
-					collectSearchTest<EuclidianPoint, EuclidianMetric,SPMTree<EuclidianPoint, EuclidianMetric>>
+				for (const auto& madi : apmt_madis){
+					collectSearchTest<EuclidianPoint, EuclidianMetric,APMTree<EuclidianPoint, EuclidianMetric>>
 					(points, qPoints, EuclidianPointDim, radii, false, pivType, partType, madi, fileNamePrefix, hflag, rangeSearchToo);
-					if (hflag == true) {hflag = false;}
+					{hflag = false;}
 				}
 			}
 		}
@@ -683,8 +713,8 @@ void radiusSearchCompareEM(unsigned int nPoints, const unsigned int nQueries, Pi
 	auto [points, qPoints] = generatePointsBrin95(nPoints, nQueries);
 
 	auto start = std::clock();
-	//SPMTree<EuclidianPoint, MetricType> stree(points, met);
-	CMTree<EuclidianPoint, MetricType> stree(points, met,pivT, partT, kxBalancedTreeHeight(1,points.size()));
+	APMTree<EuclidianPoint, MetricType> stree(points, met);
+	//CMTree<EuclidianPoint, MetricType> stree(points, met,pivT, partT, kxBalancedTreeHeight(1,points.size()));
 	BruteForceSearch<EuclidianPoint, MetricType> stree2(points, met);
 	bTime = dTimeSeconds(start);
 	cout << "radiusSearchTest btime=" << bTime << endl;
@@ -696,7 +726,7 @@ void radiusSearchCompareEM(unsigned int nPoints, const unsigned int nQueries, Pi
 	unsigned int nFound = 0;
 	unsigned int diffCount = 0;
 	const unsigned int maxResults = 1000000;
-	auto rad = 0.0;
+	auto rad = 0.5;
 	for (const auto& qp : qPoints) {
 		/*if(nqActual == 2) {
 			cout << "pq id="<<qp.getId() << endl;
@@ -713,7 +743,7 @@ void radiusSearchCompareEM(unsigned int nPoints, const unsigned int nQueries, Pi
 
 		if (!rq.hasSameNeighbors(rq2)) {
 			diffCount++;
-			/*
+			
 			auto missingIn1 = rq.missingNeighbors(rq2);
 			auto missingIn2 = rq2.missingNeighbors(rq);
 			std::cout << "id=" << rq.getTarget() << std::endl;
@@ -727,8 +757,8 @@ void radiusSearchCompareEM(unsigned int nPoints, const unsigned int nQueries, Pi
 			}
 			
 			std::cout << "---listing nbrs---:" << std::endl;
-			auto nba = rq.getNeigbors();
-			auto nbb = rq2.getNeigbors();
+			auto nba = rq.getNeighbors();
+			auto nbb = rq2.getNeighbors();
 			for (const auto& n : nba) {
 				std::cout << "d =" << n.distance << " id=" << n.id << std::endl;
 			}
@@ -740,7 +770,7 @@ void radiusSearchCompareEM(unsigned int nPoints, const unsigned int nQueries, Pi
 			std::cout << "-----" << std::endl;
 			int i;
 			std::cin >> i;
-			*/
+			
 		}
 
 	    nqActual++;

--- a/src/apps/EuclidianTests.h
+++ b/src/apps/EuclidianTests.h
@@ -334,7 +334,7 @@ void nkSearchTestEM(const std::string &fileNamePrefix){
 		
 	std::vector<int> cmt_madis {1,1000};
 	std::vector<int> spmt_madis{0};
-	std::vector<int> apmt_madis; // not finished {0};
+	std::vector<int> apmt_madis{0}; // not finished {0};
 
 
 	std::set<PivotType> includePivotTypes{PivotType::RAN};
@@ -785,7 +785,9 @@ void kNNSearchCompareEM(unsigned int nPoints, unsigned int nQueries,
 
 
 	std::clock_t start = std::clock();
-	CMTree<EuclidianPoint, MetricType> stree(points, met, pivT, partT, kxBalancedTreeHeight(1, points.size()));
+	//CMTree<EuclidianPoint, MetricType> stree(points, met, pivT, partT, kxBalancedTreeHeight(1, points.size()));
+	APMTree<EuclidianPoint, MetricType> stree(points, met, pivT, partT, 0);
+
 	BruteForceSearch<EuclidianPoint, MetricType> stree2(points, met);
 
 	bTime = dTimeSeconds(start);

--- a/src/apps/ExtractFasta.cpp
+++ b/src/apps/ExtractFasta.cpp
@@ -1,4 +1,3 @@
-//#define SA_USE_PARASAIL
 //#define SA_USE_STATIC_DI
 
 #include <iostream>

--- a/src/common/Misc.h
+++ b/src/common/Misc.h
@@ -120,6 +120,28 @@ genEuclidianPointsUniform(std::vector<int>::size_type nPoints, PointType start, 
 	}
 	return EuPoints;
 }
+/*
+	 Generate nPoints euclidian of equal spacing on a line. Usefull for
+	 1D debugging
+*/
+template <unsigned int DIM, class PointType>
+std::vector<EuclidianPoint>
+genEuclidianPointsOnLine(const unsigned int nPoints){
+	std::ostringstream idStream;
+	std::vector<EuclidianPoint> EuPoints;
+	EuPoints.reserve(nPoints);
+	std::array<PointType, DIM> point;
+	for (auto i = 0; i < nPoints; i++){
+		for (auto j = 0; j < DIM; j++){
+			point[j] = i;
+		}
+		idStream.str("");
+		idStream.clear();
+		idStream << "_" << i;
+		EuPoints.push_back(EuclidianPoint(idStream.str(), point));
+	}
+	return EuPoints;
+}
 
 /**
 	Get a vector of DIM distribution objects.

--- a/src/metric/Metric.h
+++ b/src/metric/Metric.h
@@ -6,12 +6,14 @@
 #include <cmath>
 
 #include "Sequence.h"
-#include "ParasailInterface.h"
 #include "SmithWatermanUM.h"
 #include "Misc.h"
 #include "EditDistance.h"
 #include "edlib.h"
 
+#ifdef USE_PARASAIL_LIB
+	#include "ParasailInterface.h"
+#endif
 
 template <class T>
 class Metric {

--- a/src/metric/ParasailInterface.h
+++ b/src/metric/ParasailInterface.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#ifdef SA_USE_PARASAIL
+#ifdef USE_PARASAIL_LIB
 
 #include "parasail.h"
 #include "parasail/matrices/blosum62.h"

--- a/src/search/APMTree.h
+++ b/src/search/APMTree.h
@@ -246,14 +246,14 @@ void APMTree<T, M >::searchK(PQType& pq, const T& target, NearestKQuery<T>& sq, 
 	while (!pq.empty()) {
 		PQNodePtr qn = pq.top();
 		pq.pop();
-		auto tnd = qn->node; // tree node
-		sq.addResult(tnd->object, qn->distance);	
+		auto pnd = qn->node; // tree node
+		sq.addResult(pnd->object, qn->distance);	
 		if(qn->pruningDist <= sq.searchRadius()) {
 			auto pqDist = qn->distance;
-			auto lnd = tnd->left;
-			auto rnd = tnd->right;
+			auto lnd = pnd->left;
+			auto rnd = pnd->right;
 			if (lnd != nullptr) {
-				if (tnd->diL.rangeOverlaps(pqDist, sq.searchRadius()) == true) {
+				if (pnd->diL.rangeOverlaps(pqDist, sq.searchRadius()) == true) {
 					this->perfStats.incNodesVisited();
 					auto dist = met.distance(&target, lnd->object);
 					this->perfStats.incDistanceCalls();
@@ -262,7 +262,7 @@ void APMTree<T, M >::searchK(PQType& pq, const T& target, NearestKQuery<T>& sq, 
 				}
 			}
 			if (rnd != nullptr) {
-				if (tnd->diR.rangeOverlaps(pqDist, sq.searchRadius()) == true){
+				if (pnd->diR.rangeOverlaps(pqDist, sq.searchRadius()) == true){
 					this->perfStats.incNodesVisited();
 					auto dist = met.distance(&target, rnd->object);
 					this->perfStats.incDistanceCalls();
@@ -274,22 +274,9 @@ void APMTree<T, M >::searchK(PQType& pq, const T& target, NearestKQuery<T>& sq, 
 	}
 }
 
-	// auto pd = pruningDistance<double>(dist, std::min(nd->diL.getNear(), nd->diR.getNear()), nd->diR.getFar());
-	/// Worked:
-	/*
-	if (nd->left != nullptr){
-		auto pd = pruningDistance<double>(dist, nd->diL.getNear(), nd->diL.getFar());
-		if (pd <= sq.searchRadius()){
-			searchR(nd->left, target, sq, met);
-		}
-	}
-	if (nd->right != nullptr){
-		auto pd = pruningDistance<double>(dist, nd->diR.getNear(), nd->diR.getFar());
-		if (pd <= sq.searchRadius()) {
-			searchR(nd->right, target, sq, met);
-		}
-	}
-	****/
+/*
+Range search function
+**/
 template <typename T, typename M>
 void APMTree<T, M>::searchR(NodePtr& nd, const T& target, RadiusQuery<T>& sq, M& met) {
     if (nd == nullptr)
@@ -300,8 +287,6 @@ void APMTree<T, M>::searchR(NodePtr& nd, const T& target, RadiusQuery<T>& sq, M&
     sq.addResult(nd->object, dist);
 
     if (nd->left != nullptr) {
-        // if (dist <= nd->diL.getFar() + sq.searchRadius()){
-        //if (nd->rangeOverlapsLeft(dist, sq.searchRadius())) {
 		if (nd->diL.rangeOverlaps(dist, sq.searchRadius())) {	
             searchR(nd->left, target, sq, met);
         }
@@ -315,8 +300,9 @@ void APMTree<T, M>::searchR(NodePtr& nd, const T& target, RadiusQuery<T>& sq, M&
 }
 
 template <typename T, typename M>
-void APMTree<T, M >::searchCollect(NodePtr& nd, const T& target, SimilarityQuery<T>& sq, M& met) {
-    if (nd == nullptr) return;
+void APMTree<T, M>::searchCollect(NodePtr& nd, const T& target, SimilarityQuery<T>& sq, M& met) {
+    if (nd == nullptr)
+        return;
 
     this->perfStats.incNodesVisited();
     auto dist = met.distance(&target, nd->object);
@@ -328,10 +314,8 @@ void APMTree<T, M >::searchCollect(NodePtr& nd, const T& target, SimilarityQuery
     } else {
         sq.addResult(nd->object, dist);
         if (nd->left != nullptr) {
-           	// if (nd->rangeOverlapsLeft(dist, sq.searchRadius())) {
-            // if (dist <= nd->diL.getFar() + sq.searchRadius()){
-	  if (nd->diL.rangeOverlaps(dist, sq.searchRadius())) {
-	    searchCollect(nd->left, target, sq, met);
+            if (nd->diL.rangeOverlaps(dist, sq.searchRadius())) {
+                searchCollect(nd->left, target, sq, met);
             }
         }
         if (nd->right != nullptr) {
@@ -342,7 +326,6 @@ void APMTree<T, M >::searchCollect(NodePtr& nd, const T& target, SimilarityQuery
     }
     return;
 }
-
 
 /*
 	

--- a/src/search/APMTree.h
+++ b/src/search/APMTree.h
@@ -1,0 +1,354 @@
+#ifndef APMTREE_H
+#define APMTREE_H
+
+/**
+ *  @file    APMTree.h
+ *  @date    June 2022
+ *
+ *  @brief A C++ implementation of the priority metric tree.
+ *
+ *  @section DESCRIPTION
+ *
+ *  This is a C++ implementation of the priority ball metric tree.  Tree nodes store the bounding interval
+ *  of pivot distances of the left child and right child. This is roughly equivalent to the original 
+ *  Ball Metric Tree of Uhlmann (1991) and the VP-1 tree of Yanilos (1993) since the internal distances
+ *  of the two intervals are roughly equivalent to the partitioning distance and its the most usefull
+ *  info for pruning (The external distances of the two intervals are significantly less usefull). 
+ *  Added is a priority queue used for determining node order visitaation in kNN search. This version 
+ *  also supports collection search and range bounded kNN search.
+ *
+**/
+
+#include <vector>
+#include <algorithm>
+#include <memory>
+#include <iostream>
+#include <cmath>
+#include <fstream>
+#include <queue>
+
+#include "TreeNodes.h"
+#include "Query.h"
+#include "PerfStats.h"
+#include "SearchCommon.h"
+#include "DistanceInterval.h"
+#include "SearchPQ.h"
+#include "SPMTree.h"
+
+template < typename T, typename M>
+class APMTree : public  SPMTree_Base<ANode<T>, T, M> {
+	protected:
+	const std::string myShortName{ "APMT" };
+	using Node = ANode<T>;  
+	using NodePtr = Node*;
+	using NodeItr = typename std::vector<APMTree<T, M>::Node*>::iterator;
+	using PQNode = SPQNode<Node>;
+	using PQNodePtr = PQNode*;
+	//Comparator for the priority queue
+	class CompareResultPQ {
+	public:
+		bool operator()(const PQNode* lhs, const PQNode* rhs) const {
+			return lhs->pruningDist > rhs->pruningDist;
+		}
+	};
+	using PQType = SearchPQ<Node, PQNode, CompareResultPQ >;
+	
+
+	void searchK(PQType& pq, const T& target, NearestKQuery<T>& sq, M& met);
+	void searchR(NodePtr& nd, const T & target, RadiusQuery<T> & sq, M & met);
+	void searchCollect(NodePtr& nd, const T& target, SimilarityQuery<T>& sq, M& met);
+	void collect(NodePtr& nd, SimilarityQuery<T>& sq, M& met, const double dist);
+	Node* buildTreeAlt(const NodeItr begin, const NodeItr end);
+	void partition(const NodeItr firstC, NodeItr& median, const NodeItr end);
+	void radiusSumAndDepths(NodePtr& nd, unsigned int depth, double& dsum, std::set<unsigned int>& depths);
+	void calculateDI(NodeItr ndPtr, const NodeItr begin,  const NodeItr median, const NodeItr end);
+public:
+	APMTree(std::vector < T >& objects, const M& met,
+		PivotType pivT = PivotType::RAN, PartType partT = PartType::BOM, const unsigned int madi = 0) :
+	      SPMTree_Base<ANode<T>, T, M>::SPMTree_Base(objects, met, pivT, partT) {
+	std::cout << "APMTree buildTree starting" << std::endl;
+	this->root = this->buildTreeAlt(this->nodes.begin(), this->nodes.end());
+	std::cout << "APMTree buildTree finished" << std::endl;
+
+	}
+
+	void searchCollect(SimilarityQuery<T> & q);	
+	void search(RadiusQuery<T> & q);
+	void search(NearestKQuery<T>& q);
+	double radiusSumAndDepths(std::set<unsigned int>& depths);
+
+	std::string shortName() const { return myShortName; }
+
+};
+
+/**
+buildTreeAlt() is the an alternaltive tree building algorithm allows for the selection of different
+pivot selection and partitioning algorithms  - mostly for experimental purposes. The other buildTree
+algorithms are mostly "fixed" in selection and partitioning algorithms.
+**/
+
+template <typename T, typename M>
+typename APMTree<T, M>::Node *
+APMTree<T, M>::buildTreeAlt(const NodeItr begin, const NodeItr end)
+{
+	if (begin == end){
+		return nullptr;
+	}
+	int size =end - begin;
+
+	if ( size == 1){
+		(*begin)->setLeaf();
+		return *begin;
+	}
+
+	const auto firstC = begin + 1;			   // iterator pointing to first child
+	auto median = firstC + (end - firstC) / 2; // median of the children
+
+	LessThanLen<Node> ltl;
+	auto pivotItr = selectPivot<T, M, NodeItr, LessThanLen<Node>>(begin, median, end,
+																  this->pivotType, ltl, this->metric);
+	std::iter_swap(begin, pivotItr);
+	(*begin)->size= size;
+
+	for (auto itr = firstC; itr != end; itr++){
+		(*itr)->sstemp = this->metric.distance((*begin)->object, (*itr)->object);
+	}
+
+	this->partition(firstC, median, end);
+
+	this->calculateDI(begin, firstC, median, end);
+
+	(*begin)->left = buildTreeAlt(firstC, median);
+	(*begin)->right = buildTreeAlt(median, end);
+
+	return *begin;
+}
+
+/*
+	Partiton the set in interval [fistC,end) based upon the user selected PartitioningType.
+	Note: far is set hold a temp value for patitioning but it is not set back.
+*/
+template <typename T, typename M>
+void APMTree<T, M >::partition(const NodeItr firstC, NodeItr& median, const NodeItr end) {
+if (this->partitionType == PartType::BOM) {
+		//Balanced (|LHS|=|RHS|) Object Median Partition.
+		std::nth_element(firstC, median, end, LessThanTemp<Node>());
+	}
+	else {
+		error("partition function default");
+	}
+}
+
+/*
+
+/*
+	Find and store the bounding intervals of te left and right child. 
+	We asume the distances to parents are stored
+	in the value far.
+*/
+template <typename T, typename M>
+void APMTree<T, M>::calculateDI(const NodeItr nd, const NodeItr begin, const NodeItr median, const NodeItr end)
+{
+	if (begin == end){
+		// for leaf nodes
+		(*nd)->diL.setNear(0);
+		(*nd)->diL.setFar(0);
+		(*nd)->diR.setNear(0);
+		(*nd)->diR.setFar(0);
+	}
+	else{
+		auto near = std::numeric_limits<float>::max();
+		auto far = 0.0;
+		for (auto p = begin; p != median; p++){
+			if ((*p)->sstemp < near)
+				near = (*p)->sstemp;
+			if ((*p)->sstemp > far)
+				far = (*p)->sstemp;
+		}
+		(*nd)->diL.setNear(near);
+		(*nd)->diL.setFar(far);
+		// And same for RHS child node:
+		near = std::numeric_limits<float>::max();
+		far = 0.0;
+		for (auto p = median; p != end; p++){
+			if ((*p)->sstemp < near)
+				near = (*p)->sstemp;
+			if ((*p)->sstemp > far)
+				far = (*p)->sstemp;
+		}
+		(*nd)->diR.setNear(near);
+		(*nd)->diR.setFar(far);
+	}
+}
+
+/*
+Users public interface search method which will call the basic search methods.
+*/
+template <typename T, typename M>
+void APMTree<T, M>::search(RadiusQuery<T>& q) {
+  if (this->root != nullptr) {
+    searchR(this->root, q.getTarget(), q, this->metric);
+  }
+}
+
+template <typename T, typename M>
+void APMTree<T, M>::search(NearestKQuery<T>& q) {
+  
+  if (this->root != nullptr) {
+    PQType queue;
+    auto dist = this->metric.distance(&(q.getTarget()), this->root->object);
+	 this->perfStats.incNodesVisited();
+  	this->perfStats.incDistanceCalls();
+	auto pd = pruningDistance<double>(dist, this->root->diL.getNear(), this->root->diR.getFar());
+    queue.push(queue.newNode(this->root, nullptr, dist, pd));
+    searchK(queue, q.getTarget(), q, this->metric);
+  }
+}
+
+//SearchCollect should only work with RadiusQuery or RadiusCountQuery
+template <typename T, typename M>
+void APMTree<T, M >::searchCollect(SimilarityQuery<T>& q) {
+	if (this->root != nullptr) {
+		std::vector <double> distStack;
+		searchCollect(this->root, q.getTarget(), q, this->metric);
+	}
+}
+
+//KNN search implementation.
+template <typename T, typename M>
+void APMTree<T, M >::searchK(PQType& pq, const T& target, NearestKQuery<T>& sq, M& met) {
+	std::cout <<"This function is not finished and  tested" << std::endl; 
+	std::exit(-1);
+	while (!pq.empty()) {
+		PQNodePtr qn = pq.top();
+		pq.pop();
+		sq.addResult(qn->node->object, qn->distance);	
+		if(qn->pruningDist <= sq.searchRadius()) {
+			auto tnd = qn->node; // tree node
+			auto pqDist = qn->distance;
+			auto lnd = tnd->left;
+			auto rnd = tnd->right;
+			if (lnd != nullptr) {
+				if ( pqDist <= tnd->diL.getFar() + sq.searchRadius())  {
+					this->perfStats.incNodesVisited();
+					auto dist = met.distance(&target, lnd->object);
+					this->perfStats.incDistanceCalls();
+					auto pd = pruningDistance<double>(dist,  lnd->diL.getNear(),  lnd->diR.getFar());
+					pq.push(pq.newNode(lnd, qn, dist, pd));
+				}
+			}
+			if (rnd != nullptr) {
+				if (pqDist >= tnd->diR.getNear() - sq.searchRadius()){
+			   	this->perfStats.incNodesVisited();
+				auto dist = met.distance(&target, rnd->object);
+			    this->perfStats.incDistanceCalls();
+				auto pd = pruningDistance<double>(dist,  rnd->diL.getNear(), rnd->diR.getFar());
+				pq.push(pq.newNode(rnd, qn, dist, pd));
+			}
+		}
+	}
+	}
+}
+
+	// auto pd = pruningDistance<double>(dist, std::min(nd->diL.getNear(), nd->diR.getNear()), nd->diR.getFar());
+	/// Worked:
+	/*
+	if (nd->left != nullptr){
+		auto pd = pruningDistance<double>(dist, nd->diL.getNear(), nd->diL.getFar());
+		if (pd <= sq.searchRadius()){
+			searchR(nd->left, target, sq, met);
+		}
+	}
+	if (nd->right != nullptr){
+		auto pd = pruningDistance<double>(dist, nd->diR.getNear(), nd->diR.getFar());
+		if (pd <= sq.searchRadius()) {
+			searchR(nd->right, target, sq, met);
+		}
+	}
+	****/
+template <typename T, typename M>
+void APMTree<T, M>::searchR(NodePtr& nd, const T& target, RadiusQuery<T>& sq, M& met) {
+ 	if (nd == nullptr)
+		return;
+  	
+	this->perfStats.incNodesVisited();
+
+ 	auto dist = met.distance(&target, nd->object);
+ 	this->perfStats.incDistanceCalls();
+
+  	sq.addResult(nd->object, dist);
+
+	if (nd->left != nullptr){
+		if (dist <= nd->diL.getFar() + sq.searchRadius()){
+			searchR(nd->left, target, sq, met);
+		}
+  	}
+  	if (nd->right != nullptr){
+	  	if (dist >= nd->diR.getNear() - sq.searchRadius()){
+			  searchR(nd->right, target, sq, met);
+	  	}
+  	}
+}
+
+template <typename T, typename M>
+void APMTree<T, M >::searchCollect(NodePtr& nd, const T& target, SimilarityQuery<T>& sq, M& met) {
+	std::cout <<"This function is not finished and  tested" << std::endl; 
+	std::exit(-1);
+	if (nd == nullptr) return;
+		
+	this->perfStats.incNodesVisited();
+	auto dist = met.distance(&target, nd->object);
+	this->perfStats.incDistanceCalls();
+
+	if(dist + nd->diR.getFar() <=  sq.searchRadius()){
+		collect(nd, sq, met, dist + nd->diR.getFar() );
+	}else{
+		sq.addResult(nd->object, dist);
+		auto pd = pruningDistance<double>(dist, nd->diR.getNear(), nd->diR.getFar());
+		if (pd <= sq.searchRadius()) {
+			if (nd->left != nullptr){
+				if (dist <= nd->diL.getFar() + sq.searchRadius()){
+						searchCollect(nd->left, target, sq, met);
+				}
+			}
+			if (nd->right != nullptr){
+	  			if (dist >= nd->diR.getNear() - sq.searchRadius()){
+						searchCollect(nd->right, target, sq, met);
+				}	
+			}
+		}
+	}
+	return;
+}
+
+
+/*
+	
+*/
+template <typename T, typename M>
+double APMTree<T, M>::radiusSumAndDepths(std::set<unsigned int>& depths) {
+	double sum = 0.0;
+	radiusSumAndDepths(this->root, 0, sum, depths);
+	return sum;
+}
+/*
+	Traverse the tree to collect the sum of the radius and the depths of the tree.
+	(These are used as measures of tree building correctness)
+*/
+
+template <typename T, typename M>
+void APMTree<T, M >::radiusSumAndDepths(NodePtr& nd,  unsigned int depth, double& dsum, std::set<unsigned int>& depths) {
+	if (nd->isLeaf()) {
+		depths.insert(depth);
+		return;
+	}
+	//if (di.size() > 0)
+	dsum += nd->diR.getFar();
+	if (nd->left != nullptr)
+		radiusSumAndDepths(nd->left, depth + 1, dsum, depths);
+	if (nd->right != nullptr)
+		radiusSumAndDepths(nd->right, depth + 1, dsum, depths);
+}
+
+
+#endif

--- a/src/search/DistanceInterval.h
+++ b/src/search/DistanceInterval.h
@@ -5,31 +5,128 @@
 #include <vector>
 #include <memory>
 #include <iostream>
+#include <cmath>
 #include "Misc.h"
 #include "MemoryAux.h"
+
+#define USE_NEXTAFTER 1
 
 template <typename T>
 class DistanceInterval {
 private:
 	T d[2]; //Also possible: T near, far;
 public:
-	DistanceInterval(T nd, T fd) {
+	DistanceInterval(const T nd, const T fd) {//Note std::nextafter not used in contructor.
 		d[0] = nd; d[1] = fd;
 	}
 	DistanceInterval() {
 		d[0] = 0; d[1] = 0;
 	}
-	inline void setNear(T nd) { d[0] = nd; }
-	inline void setFar(T fd) { d[1] = fd; }
-	inline T getNear() { return d[0]; }  //TODO: return T or T&
-	inline T getFar() { return d[1]; }
+	inline void setNear(const T nd) { 
+	#ifndef USE_NEXTAFTER
+		d[0] = nd; 
+	#else
+		d[0] = std::nextafter(nd,  0.0f);
+	#endif
+	}
+	inline void setFar(const T nd) { 
+	#ifndef USE_NEXTAFTER
+		d[1] = nd; 
+	#else
+		d[1] = std::nextafter(nd,  std::numeric_limits<float>::max());
+	#endif
+	}
+	inline const T getNear() { return d[0]; } 
+	inline const T getFar() { return d[1]; }
+	inline void reset() { d[0] = 0; d[1] = 0; }
 	DistanceInterval& operator = (const DistanceInterval& that) {
 		d[0] = that.d[0];
 		d[1] = that.d[1];
 		return *this;
 	}
-	
+	inline bool rangeOverlaps(const double pqDistance, const double radius) {
+        if ((pqDistance >= getNear() - radius) &&
+            (pqDistance <= getFar() + radius)) {
+            return true;
+        } else {
+            return false;
+        }
+	}
 };
+/*
+	Half open distance intervals for rhs data
+*/
+template <typename T>
+class LeftHDI {
+private:
+	T d; 
+public:
+	LeftHDI(const T dist) {
+		d = dist;
+	}
+	LeftHDI() {
+		d = 0;
+	}
+	inline void setFar(const T nd) { 
+	#ifndef USE_NEXTAFTER
+		d = nd; 
+	#else
+		d = std::nextafter(nd,  std::numeric_limits<float>::max());
+	#endif
+	}
+	inline const T getFar() { return d; }  
+	inline const T getNear() { return 0; }  //used in pruing priority
+	inline void reset() { d = 0; }
+	LeftHDI& operator = (const LeftHDI& that) {
+		d = that.d;
+		return *this;
+	}
+	inline bool rangeOverlaps( const double pqDistance, const double radius){
+		if (pqDistance <= getFar() + radius){
+			return true;
+		}else{
+			return false;
+		}
+	}
+};
+
+template <typename T>
+class RightHDI {
+private:
+	T d; 
+public:
+	RightHDI(const T dist) {
+		d = dist;
+	}
+	RightHDI() {
+		d = 0;
+	}
+	inline void setNear(const T nd) {
+	#ifndef USE_NEXTAFTER
+		d = nd; 
+	#else
+		d = std::nextafter(nd, 0.0f);
+	#endif
+	}
+	inline const T getNear() { return d; }
+	inline const T getFar() { return  std::numeric_limits<float>::max(); }//used in pruning priority
+
+	inline void reset() { d = 0; }
+	RightHDI& operator = (const RightHDI& that) {
+		d = that.d;
+		return *this;
+	}
+	inline bool rangeOverlaps( const double pqDistance, const double radius){
+			 if (pqDistance + radius >= getNear()){
+			return true;
+		}else{
+			return false;
+		}
+	}
+};
+
+
+
 
 //A DistanceInterval with data of instances in one large static rarray:
 template <typename T>

--- a/src/search/DistanceInterval.h
+++ b/src/search/DistanceInterval.h
@@ -9,7 +9,13 @@
 #include "Misc.h"
 #include "MemoryAux.h"
 
-#define USE_NEXTAFTER 1
+
+/**
+ * Define USE_NEXTAFTER to expand the bounding interval bounds (sides) to the next lowest and 
+ * next highest representable floats. Otherwise you may need to expand the radius by epsilon (~1/(10^6))
+ * or (possibly) store bounding intervals as doubles.
+ * 
+ */
 
 template <typename T>
 class DistanceInterval {
@@ -54,7 +60,8 @@ public:
 	}
 };
 /*
-	Half open distance intervals for rhs data
+	Half open distance intervals for LHS of set partition
+	(assiged to left node)
 */
 template <typename T>
 class LeftHDI {
@@ -90,6 +97,10 @@ public:
 	}
 };
 
+/**
+Half open distance intervals for RHS of set partition
+	(assiged to left node)
+	*/
 template <typename T>
 class RightHDI {
 private:

--- a/src/search/PartitionFunction.h
+++ b/src/search/PartitionFunction.h
@@ -1,0 +1,86 @@
+#ifndef CMT_PARTITION_FUNCTION
+#define CMT_PARTITION_FUNCTION
+
+#include <algorithm>
+#include <vector>
+
+#include "SearchCommon.h"
+#include "TreeNodes.h"
+
+// Abstract base class
+template < typename N, typename  NodeItr, typename T, typename M>                                                                                                                                                                                                 
+class PartitionFunction {
+public:
+  PartitionFunction() {};
+  virtual void operator() (const NodeItr firstC, NodeItr& median, const NodeItr end) = 0;
+};
+
+// Add two doubles 
+template < typename N, typename  NodeItr, typename T, typename M>                                                                                                                                                                                                     
+class BOM : public PartitionFunction<N,NodeItr,T,M> {
+public:
+  BOM() {};
+  virtual void operator() (const NodeItr firstC, NodeItr& median, const NodeItr end) { 
+    std::nth_element(firstC, median, end, LessThanTemp<N>());
+    return;
+     }
+};
+
+template < typename N, typename  NodeItr, typename T, typename M>
+class DMR : public PartitionFunction<N,NodeItr,T,M>{
+public:
+    DMR(){};
+    virtual void operator()(const NodeItr firstC, NodeItr &median, const NodeItr end){
+        auto minElem = std::min_element(firstC, end, LessThanTemp<N>());
+        auto maxElem = std::max_element(firstC, end, LessThanTemp<N>());
+        double medDist = 0.5 * ((*maxElem)->sstemp + (*minElem)->sstemp);
+
+        LessThanVal<N> ltm(medDist);
+        median = std::stable_partition(firstC, end, ltm);
+        // One way to take care of degenerate case:
+        if (median == firstC || median == end)
+        {
+            median = firstC + (end - firstC) / 2;
+        }
+        return;
+    }
+};
+
+
+template < typename N, typename  NodeItr, typename T, typename M>
+PartitionFunction<N,NodeItr,T,M> * getPartitionFunctor(PartType pType){
+  PartitionFunction<N,NodeItr,T,M>  * ftor = nullptr;
+    if(pType == PartType::BOM){
+      ftor = new BOM<N,NodeItr,T,M>();
+    }else if(pType == PartType::DMR){
+      ftor = new DMR<N,NodeItr,T,M>();
+    }else{
+      std::cout <<"Error in getPartitionFunctor"<<std::endl;
+      exit(-1);
+    }
+    return ftor;
+}
+
+
+template<class T, class Node, class  NodeItr, class Comparator>
+inline std::tuple<T,T> getNearFar( const NodeItr begin, const NodeItr end, Comparator& compare){
+  auto nearFar = std::minmax_element(begin, end, compare);
+         //[] (Node const* lhs, Node const* rhs) {return lhs->sstemp < rhs->sstemp;});
+	T near = (*nearFar.first)->sstemp;
+  T far = (*nearFar.second)->sstemp;
+  return {near, far};
+}
+
+
+/*
+  Determine and set the bouding distance interval di from the
+  node->sstemp variable in the container of nodes, using nodes in [begin,end)
+*/
+template <class Node, class NodeItr, class Comparator>
+inline void calculateDBI(DI & di, const NodeItr begin, const NodeItr end, Comparator& compare){
+  auto [nearL, farL] = getNearFar<float, Node, NodeItr>(begin, end, compare);
+  di.setNear(nearL);
+  di.setFar(farL);
+}
+
+#endif

--- a/src/search/PartitionFunction.h
+++ b/src/search/PartitionFunction.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "DistanceInterval.h"
 #include "SearchCommon.h"
 #include "TreeNodes.h"
 
@@ -77,10 +78,20 @@ inline std::tuple<T,T> getNearFar( const NodeItr begin, const NodeItr end, Compa
   node->sstemp variable in the container of nodes, using nodes in [begin,end)
 */
 template <class Node, class NodeItr, class Comparator>
-inline void calculateDBI(DI & di, const NodeItr begin, const NodeItr end, Comparator& compare){
+inline void calculateDBI(DistanceInterval<float> & di, const NodeItr begin, const NodeItr end, Comparator& compare){
   auto [nearL, farL] = getNearFar<float, Node, NodeItr>(begin, end, compare);
   di.setNear(nearL);
   di.setFar(farL);
+}
+template <class Node, class NodeItr, class Comparator>
+inline void calculateDBI(LeftHDI<float> & di, const NodeItr begin, const NodeItr end, Comparator& compare){
+  auto [nearL, farL] = getNearFar<float, Node, NodeItr>(begin, end, compare);
+  di.setFar(farL);
+}
+template <class Node, class NodeItr, class Comparator>
+inline void calculateDBI(RightHDI<float> & di, const NodeItr begin, const NodeItr end, Comparator& compare){
+  auto [nearL, farL] = getNearFar<float, Node, NodeItr>(begin, end, compare);
+  di.setNear(nearL);
 }
 
 #endif

--- a/src/search/Query.h
+++ b/src/search/Query.h
@@ -200,7 +200,7 @@ public:
 		for (const auto& n : neighbors) {
 			ids.insert(n.id);
 		}
-		for (const auto& n : qB.getNeigbors()) {
+		for (const auto& n : qB.getNeighbors()) {
 			if (ids.find(n.id) == ids.end()) {
 				missing.insert(n);
 			}

--- a/src/search/SearchCommon.h
+++ b/src/search/SearchCommon.h
@@ -32,11 +32,11 @@ namespace PerfStatsNS {
 	CENT => center
 */
 enum class PivotType { RAN};//Random, Extreme, MINIMUM, median, center, N/4
-enum class PartType {BOM};
+enum class PartType {BOM, DMR};
 
 static std::map<PivotType, std::string> pivotTypeMap{ {PivotType::RAN, "RAN"} };
 
-static std::map<PartType, std::string> partTypeMap{ {PartType::BOM, "BOM"}};
+static std::map<PartType, std::string> partTypeMap{ {PartType::BOM, "BOM"}, {PartType::DMR, "DMR"}};
 
 std::ostream& operator<<(std::ostream& os, PivotType p) {
 	os << pivotTypeMap.at(p);

--- a/src/search/TreeNodes.h
+++ b/src/search/TreeNodes.h
@@ -23,7 +23,8 @@ public:
 	int size;
 	FSVector<DI> adi;//the ancestral distance interrval
 	//std::vector<DI> adi;
-	DistanceInterval<float>    di; //Normal child distance interval
+	DistanceInterval<float>    diL, diR; //Normal child distance intervals
+
 	//std::vector<float> dpivots;//Note that sizeof(std::vector<float>) =24 bytes on a 64 bit Windows 
 	std::deque<float> dpivots; //TODO: fix above
 	float sstemp;
@@ -32,9 +33,23 @@ public:
 	bool isLeaf() { return ((left == nullptr) && (right == nullptr)); }
 	void setLeaf() {
 		left = nullptr;  right = nullptr;
-		di.setNear(0); di.setFar(0);
+		diL.setNear(0); diL.setFar(0); diR.setNear(0); diR.setFar(0);
 	}
-
+	float getNear(){
+		if (left != nullptr){
+			return diL.getNear();
+		}else{
+			return diR.getNear();
+		}
+	}
+	// get the furthest from among both left and right.	
+	float getFar(){
+		if (right != nullptr){
+			return diR.getFar();
+		}else{
+			return diL.getFar();
+		}
+	}
 	friend std::ostream& operator<<(std::ostream& os, CNode& nd) {
 		os << "(" << nd.object << ")";
 		return os;
@@ -69,6 +84,22 @@ public:
 	ANode(T* object) : object{ object } {}
 	bool isLeaf() { return ((left == nullptr) && (right == nullptr)); }
 	void setLeaf() { left = nullptr;  right = nullptr; }
+	// get the nearest from among both left and right.
+	float getNear(){
+		if (left != nullptr){
+			return diL.getNear();
+		}else{
+			return diR.getNear();
+		}
+	}
+	// get the furthest from among both left and right.	
+	float getFar(){
+		if (right != nullptr){
+			return diR.getFar();
+		}else{
+			return diL.getFar();
+		}
+	}
 };
 
 /**

--- a/src/search/TreeNodes.h
+++ b/src/search/TreeNodes.h
@@ -20,10 +20,10 @@ public:
 	T* object; 
 	CNode* left;
 	CNode* right;
+	int size;
 	FSVector<DI> adi;//the ancestral distance interrval
 	//std::vector<DI> adi;
 	DistanceInterval<float>    di; //Normal child distance interval
-
 	//std::vector<float> dpivots;//Note that sizeof(std::vector<float>) =24 bytes on a 64 bit Windows 
 	std::deque<float> dpivots; //TODO: fix above
 	float sstemp;
@@ -46,11 +46,27 @@ template <class T>
 class MNode {
 public:
 	T* object;           // Point or object selected as pivot - one per node.
+	int size;
 	DistanceInterval<float> di; 
 	double sstemp;//Used a temp variable and aslo for sef score after tree is done.
 	MNode* left;  //I.e. left child, etc.
 	MNode* right;
 	MNode(T* object) : object{ object } {}
+	bool isLeaf() { return ((left == nullptr) && (right == nullptr)); }
+	void setLeaf() { left = nullptr;  right = nullptr; }
+};
+
+//Metric tree nodes.
+template <class T>
+class ANode {
+public:
+	T* object;           // Point or object selected as pivot - one per node.
+	int size;
+    DistanceInterval<float> diL, diR;
+	double sstemp;//Used a temp variable and aslo for sef score after tree is done.
+	ANode* left;  //I.e. left child, etc.
+	ANode* right;
+	ANode(T* object) : object{ object } {}
 	bool isLeaf() { return ((left == nullptr) && (right == nullptr)); }
 	void setLeaf() { left = nullptr;  right = nullptr; }
 };


### PR DESCRIPTION
This PR addresses CMT github issues 4,5, and 6 by the following:
a) Adds the use of the internal bounding interval information (the left far and right near) to the nodes
bounding intervals (for the CMT and the APMTree - a new version of the SPMTree).
b) Modifies the various search functions to use the internal bounding info.
c) Provides the capability to use (slightly) loose bounding intervals 
d) Moves many of the hard-coded (via #define statements) compilation options to the compilation configuration.
e) Provides a better encapsulation of the interval concept.
f) Cleans the tree building functions. Now there are two high-level types depending on whether or not the
   node object is the pivoting object.

Note that the APMTree is a replacement for the SPMTree, which will be removed in a future merge.